### PR TITLE
Add ability to have individual developer settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ DerivedData/
 ## Secrets
 Generated
 Secrets.xcconfig
+DeveloperSettings.xcconfig
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+"swiftlint"
+"sourcery"

--- a/Hadge.xcodeproj/project.pbxproj
+++ b/Hadge.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		4DF685A02464D0EE00D929EC /* FilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
 		4DF685A32465AEDC00D929EC /* FilterHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterHeaderView.swift; sourceTree = "<group>"; };
 		4DF685A52465B21F00D929EC /* FilterHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FilterHeaderView.xib; sourceTree = "<group>"; };
+		DE5A8AC22739D9930048B9A0 /* HadgeConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = HadgeConfig.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -189,6 +190,7 @@
 				4D3DFA4F2470571B00EDCBEC /* ReadMeTemplate.md */,
 				4D886C4024718AD30088CF56 /* Secrets.template.xcconfig */,
 				4D886C4124718B240088CF56 /* Secrets.xcconfig */,
+				DE5A8AC22739D9930048B9A0 /* HadgeConfig.xcconfig */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -430,7 +432,7 @@
 /* Begin XCBuildConfiguration section */
 		4DB3F6862453F7B0004C8BF3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D886C4124718B240088CF56 /* Secrets.xcconfig */;
+			baseConfigurationReference = DE5A8AC22739D9930048B9A0 /* HadgeConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -492,7 +494,7 @@
 		};
 		4DB3F6872453F7B0004C8BF3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D886C4124718B240088CF56 /* Secrets.xcconfig */;
+			baseConfigurationReference = DE5A8AC22739D9930048B9A0 /* HadgeConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -548,18 +550,16 @@
 		};
 		4DB3F6892453F7B0004C8BF3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D886C4124718B240088CF56 /* Secrets.xcconfig */;
+			baseConfigurationReference = DE5A8AC22739D9930048B9A0 /* HadgeConfig.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Hadge/Hadge.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Q25LVLEHFB;
 				INFOPLIST_FILE = Hadge/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.entire.hadge;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ORGANIZATION_IDENTIFIER).hadge";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -568,18 +568,16 @@
 		};
 		4DB3F68A2453F7B0004C8BF3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D886C4124718B240088CF56 /* Secrets.xcconfig */;
+			baseConfigurationReference = DE5A8AC22739D9930048B9A0 /* HadgeConfig.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Hadge/Hadge.entitlements;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Q25LVLEHFB;
 				INFOPLIST_FILE = Hadge/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.entire.hadge;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(ORGANIZATION_IDENTIFIER).hadge";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/Hadge/HadgeConfig.xcconfig
+++ b/Hadge/HadgeConfig.xcconfig
@@ -1,0 +1,11 @@
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+#include "Secrets.xcconfig"
+
+DEVELOPMENT_TEAM = Q25LVLEHFB
+CODE_SIGN_IDENTITY = Apple Development
+CODE_SIGN_STYLE = Automatic
+ORGANIZATION_IDENTIFIER = io.entire
+
+#include? "../DeveloperSettings.xcconfig"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,62 @@ Steps:
 
 Find other awesome pinned gists in matchai's [awesome-pinned-gists repo](https://github.com/matchai/awesome-pinned-gists).
 
+#### Building
+
+Hadge relies on [swiftlint](https://realm.github.io/SwiftLint/) and 
+[sourcery](https://github.com/krzysztofzablocki/Sourcery). They can be installed 
+via [homebrew](https://brew.sh) via the provided `Brewfile` by running `brew bundle`
+or manually.
+
+Hadge requires a GitHub OAuth application. You will need to create an [OAuth App](https://docs.github.com/en/developers/apps/building-oauth-apps) 
+to test and build a version of the application. Once you have your App, you will need to create a `Secrets.xcconfig`
+file  locally at the appropriate path that contains the Client ID and Client Secret.
+
+You can locally override the Xcode settings for code signing
+by creating a `DeveloperSettings.xcconfig` file locally at the appropriate path.
+
+This allows for a pristine project with theis own OAuth App and code signing set up with the appropriate
+developer ID and certificates, and for a developer to be able to have local settings
+without needing to check in anything into source control.
+
+You can do this in one of two ways: using the included `setup.sh` script or the files manually.
+
+##### Using `setup.sh`
+
+- Open Terminal and `cd` into the project directory. 
+- Run this command to ensure you have execution rights for the script: `chmod +x setup.sh`
+- Execute the script with the following command: `./setup.sh` and complete the answers.
+
+##### Manually 
+
+Create a plain text file at the root of the project directory named `DeveloperSettings.xcconfig` and
+give it the contents:
+
+```
+CODE_SIGN_IDENTITY = Apple Development
+DEVELOPMENT_TEAM = <Your Team ID>
+CODE_SIGN_STYLE = Automatic
+ORGANIZATION_IDENTIFIER = <Your Domain Name Reversed>
+```
+
+Set `DEVELOPMENT_TEAM` to your Apple supplied development team.  You can use Keychain
+Access to [find your development team ID](/Technotes/FindingYourDevelopmentTeamID.md).
+Set `ORGANIZATION_IDENTIFIER` to a reversed domain name that you control or have made up.
+
+Create a plain text file at the root of the project directory named `Hadge/Secrets.xcconfig` and
+give it the contents:
+
+```
+GITHUB_CLIENT_ID = "<Your GitHub App Client ID>"
+GITHUB_CLIENT_SECRET = "<Your GitHub App Client Secrent>"
+```
+
+Set `GITHUB_CLIENT_ID` to your GitHub App Client ID and `GITHUB_CLIENT_SECRET` to your 
+GitHub App Client Secret.
+
+Now you should be able to build without code signing errors and without modifying
+the project
+
 ## Privacy Policy
 
 This Privacy Policy describes how your personal information is handled in Hadge for iOS.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+cat << "EOF"
+.__                 .___  ____           
+|  |__  _____     __| _/ / ___\   ____   
+|  |  \ \__  \   / __ | / /_/  >_/ __ \  
+|   Y  \ / __ \_/ /_/ | \___  / \  ___/  
+|___|  /(____  /\____ |/_____/   \___  > 
+     \/      \/      \/              \/  
+                                         
+
+EOF
+
+echo This script will create a DeveloperSettings.xcconfig and Secrets.xcconfig file.
+echo 
+echo We need to ask a few questions first.
+echo 
+read -p "Press enter to get started."
+
+
+# Get the user's Developer Team ID
+echo 1. What is your Developer Team ID? You can get this from developer.apple.com.
+read devTeamID
+
+# Get the user's Org Identifier
+echo 2. What is your organisation identifier? e.g. com.developername
+read devOrgName
+
+# Get the user's Developer Team ID
+echo 1. What is your GitHub App Client ID? See README for how to create a GitHub OAuth App
+read githubClientId
+
+# Get the user's Org Identifier
+echo 2. What is your GitHub App Client Secret? See README for how to create a GitHub OAuth App
+read githubClientSecret
+
+echo Creating DeveloperSettings.xcconfig
+
+cat <<file >> DeveloperSettings.xcconfig
+CODE_SIGN_IDENTITY = Apple Development
+DEVELOPMENT_TEAM = $devTeamID
+CODE_SIGN_STYLE = Automatic
+ORGANIZATION_IDENTIFIER = $devOrgName
+file
+
+echo Creating Secrets.xcconfig
+
+cat <<file >> Hadge/Secrets.xcconfig
+GITHUB_CLIENT_ID = $githubClientId
+GITHUB_CLIENT_SECRET = $githubClientSecret
+file
+
+echo Done! 


### PR DESCRIPTION
Add ability to create local settings for the GitHub OAuth app as well as override the defaul Xcode team and organization identifier so contributors outside a defined team can contribute.

Update the README with instructions on building by creating local developer settings and GitHub OAuth App.

Add easy setup of `swiftlint` and `sourcery` with a Brewfile.

Update the project config to include developer settings if they exist.

Add `setup.sh` to easily setup local development.